### PR TITLE
Fix: apply gaps to half-tiles when maximize-with-gap is enabled

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -235,12 +235,19 @@ export class TilingWindowManager {
             );
         }
 
-        if (verticalMaximize) {
+        // When maximize-with-gap is enabled, skip the VERTICAL/HORIZONTAL maximize
+        // flag: Meta's maximize snaps the window to the full work-area extent and
+        // ignores the gapped rect computed by addGaps(), so half-tiles lose their
+        // top/bottom (or left/right) gaps. Fall through to the override_constraints
+        // path used by quarter-tiles, which preserves gaps. Mirrors the
+        // full-maximize-with-gap handling above.
+        const gappedTile = Settings.getBoolean('maximize-with-gap');
+        if (verticalMaximize && !gappedTile) {
             if (window.set_maximize_flags)
                 window.set_maximize_flags(Meta.MaximizeFlags.VERTICAL);
             else
                 window.maximize(Meta.MaximizeFlags.VERTICAL);
-        } else if (horizontalMaximize) {
+        } else if (horizontalMaximize && !gappedTile) {
             if (window.set_maximize_flags)
                 window.set_maximize_flags(Meta.MaximizeFlags.HORIZONTAL);
             else


### PR DESCRIPTION
Fixes #448.

Half-tiled windows lost their gaps on the maximized axis because `verticalMaximize` / `horizontalMaximize` apply `set_maximize_flags(...)`, and Meta's maximize snaps the window to the full work-area extent, overriding the gapped rect from `addGaps()`. Quarter-tiles are unaffected (they use the `override_constraints` path, which preserves gaps); full maximize-with-gap is also unaffected (it already skips `window.maximize()` when gaps are on).

This makes the vertical/horizontal cases consistent: when `maximize-with-gap` is enabled they skip the maximize flag and fall through to the `override_constraints` branch, so half-tiles keep their configured gaps. When `maximize-with-gap` is off, behaviour is unchanged.

**Trade-off (intentional, matches existing behaviour):** a gapped half-tile is no longer reported to Meta as vertically/horizontally *maximized* — it's a normal constrained tile, exactly like a gapped quarter-tile and like the full maximize-with-gap window. Tile-group/restore behaviour is driven by the extension's own `tiledRect`/`untiledRect` tracking, not Meta's maximize state.

**Testing:** with gaps + `maximize-with-gap` on, half-tiles now show gaps on all four edges; with `maximize-with-gap` off, half-tiles behave as before. Verified on GNOME Shell 50 / Wayland.
