### PR TITLE
moveHandler: Remove the monitor grace period timer when a grab ends

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -284,6 +284,14 @@ export default class TilingMoveHandler {
                 this._dragSprite = null;
             }
         } finally {
+            // The grace period timer captures `window`, so leaving it pending
+            // lets it re-enter _edgeTilingPreview() after the window was
+            // unmanaged, which aborts mutter.
+            if (this._latestMonitorLockTimerId) {
+                GLib.Source.remove(this._latestMonitorLockTimerId);
+                this._latestMonitorLockTimerId = null;
+            }
+
             if (this._posChangedId) {
                 window.disconnect(this._posChangedId);
                 this._posChangedId = 0;
@@ -488,7 +496,9 @@ export default class TilingMoveHandler {
                     // Only update the monitorNr, if the latest timer timed out.
                     if (timerId === this._latestMonitorLockTimerId) {
                         this._monitorNr = global.display.get_current_monitor();
-                        if (global.display.is_grabbed())
+                        // is_grabbed() is about the display, not about `window`
+                        // still being managed.
+                        if (global.display.is_grabbed() && window.get_compositor_private())
                             this._edgeTilingPreview(window, grabOp);
                     }
 

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -293,6 +293,12 @@ export default class TilingMoveHandler {
                 this._dragSprite = null;
             }
         } finally {
+            // Leaving it pending would re-enter _edgeTilingPreview() on a destroyed window
+            if (this._latestMonitorLockTimerId) {
+                GLib.Source.remove(this._latestMonitorLockTimerId);
+                this._latestMonitorLockTimerId = null;
+            }
+
             if (this._posChangedId) {
                 window.disconnect(this._posChangedId);
                 this._posChangedId = 0;
@@ -497,7 +503,8 @@ export default class TilingMoveHandler {
                     // Only update the monitorNr, if the latest timer timed out.
                     if (timerId === this._latestMonitorLockTimerId) {
                         this._monitorNr = global.display.get_current_monitor();
-                        if (global.display.is_grabbed())
+                        // check that the window still exists, and a grab is still active
+                        if (global.display.is_grabbed() && window.get_compositor_private())
                             this._edgeTilingPreview(window, grabOp);
                     }
 

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -257,7 +257,12 @@ export default class TilingMoveHandler {
 
     _onMoveFinished(window) {
         try {
-            window.assertExistence();
+            // Ignore the expected error when the window was destroyed during the grab.
+            try {
+                window.assertExistence();
+            } catch {
+                return;
+            }
 
             if (this._tileRect) {
                 // Ctrl-drag to replace some windows in a tile group / create a new tile group


### PR DESCRIPTION
Fixes the GNOME Shell abort reported in #435, which several of us have hit on Ubuntu 26.04 (@YannickMG, @cpaelzer and myself, plus the original report on Debian 13 / GNOME 48).

## The bug

`_edgeTilingPreview()` arms a 150 ms grace period timer when a drag crosses a monitor boundary, so the tile preview sticks to the previous monitor for a moment:

```js
this._latestMonitorLockTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
    if (timerId === this._latestMonitorLockTimerId) {
        this._monitorNr = global.display.get_current_monitor();
        if (global.display.is_grabbed())
            this._edgeTilingPreview(window, grabOp);
    }
    ...
```

The callback captures `window`, but the source is only ever removed in `destroy()` — never when the grab it belongs to ends. `_onMoveFinished()`'s `finally` block tears down everything else (`_posChangedId`, the tile preview, `_isGrabOp`) and leaves this one pending.

So if the dragged window is destroyed within those 150 ms — tearing off or dropping a browser tab does exactly that — the orphaned timer still fires and re-enters `_edgeTilingPreview()`, reaching:

```js
const workArea = new Rect(window.get_work_area_for_monitor(this._monitorNr));
```

`meta_window_get_work_area_for_monitor()` → `meta_window_get_workspaces()` → `g_assert_not_reached()` on an unmanaging window → `SIGABRT`. Being a C assertion, no JS guard can contain it, and the whole Wayland session dies.

The `unmanaging` JS error logged from `_onMoveFinished()` in every report is a separate, non-fatal event that merely signals the window is gone. In [my logs](https://github.com/ubuntu/Tiling-Assistant/issues/435#issuecomment-5093334916) the two are consistently ~140 ms apart, and on 2026-07-28 that error occurred with no abort at all — the session survived two more days.

## The fix

- Remove the pending source in the `finally` block of `_onMoveFinished()`, so it cannot outlive the operation that armed it. This is what actually fixes the crash.
- Additionally guard the callback with `window.get_compositor_private()`. `global.display.is_grabbed()` is a property of the display and says nothing about *this* window still being managed; the same idiom is already used in `focusHint.js:290`.

## Notes

- Only the grace period path is affected, so `monitor-switch-grace-period false` works as a user-side workaround on released versions.
- The timer is armed exclusively inside `if (this._lastMonitorNr !== currMonitorNr)`, which matches every report in #435 being multi-monitor.
- I could not build a deterministic reproducer — it is a race against a 150 ms window — so this is reasoned from four crash traces rather than from a red-to-green test. Happy to adjust if you would rather keep only the `finally` cleanup and drop the second guard.
